### PR TITLE
Fix tuple type hint syntax in prepare_point_input

### DIFF
--- a/muggled_sam/v3_sam/sampling_encoder.py
+++ b/muggled_sam/v3_sam/sampling_encoder.py
@@ -180,7 +180,7 @@ class SAMV3SamplingEncoder(nn.Module):
         assert boxes_tensor_bn22.ndim == 4, f"Unexpected box shape: {input_shape}, should be Nx2x2 or Nx4 for N boxes"
         return boxes_tensor_bn22
 
-    def prepare_point_input(self, point_xy_norm_list: list[tuple(float, float)] | None) -> Tensor | None:
+    def prepare_point_input(self, point_xy_norm_list: list[tuple[float, float]] | None) -> Tensor | None:
         """
         Helper used to convert points inputs into the tensor format needed by the model.
         Points should be given as a list of (x,y) coordinates, for example:


### PR DESCRIPTION
<details>
  <summary>Traceback</summary>
  
```
Traceback (most recent call last):
  File "/home/clay/git/upstream/muggled_sam/run_detections.py", line 159, in <module>
    model_config_dict, sammodel = make_sam_from_state_dict(model_path)
                                  ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/make_sam.py", line 37, in make_sam_from_state_dict
    make_sam_func = import_model_functions(model_type)
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/make_sam.py", line 81, in import_model_functions
    from .v3_sam.make_sam_v3 import make_samv3_from_original_state_dict as make_sam_func
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/v3_sam/make_sam_v3.py", line 10, in <module>
    from .sam_v3_model import SAMV3Model
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/v3_sam/sam_v3_model.py", line 24, in <module>
    from .sampling_encoder import SAMV3SamplingEncoder
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/v3_sam/sampling_encoder.py", line 24, in <module>
    class SAMV3SamplingEncoder(nn.Module):
    ...<185 lines>...
            return points_tensor_bn2
  File "/home/clay/git/upstream/muggled_sam/muggled_sam/v3_sam/sampling_encoder.py", line 183, in SAMV3SamplingEncoder
    def prepare_point_input(self, point_xy_norm_list: list[tuple(float, float)] | None) -> Tensor | None:
                                                           ~~~~~^^^^^^^^^^^^^^
TypeError: tuple expected at most 1 argument, got 2
```

</details>

Hit this trying your new script.